### PR TITLE
Add title when calling createHTMLDocument

### DIFF
--- a/src/pjax.js
+++ b/src/pjax.js
@@ -339,7 +339,7 @@
     }
 
   , loadContent: function(html, options) {
-      var tmpEl = document.implementation.createHTMLDocument()
+      var tmpEl = document.implementation.createHTMLDocument("")
 
         // parse HTML attributes to copy them
         // since we are forced to use documentElement.innerHTML (outerHTML can't be used for <html>)


### PR DESCRIPTION
document.implementation.createHTMLDocument in IE10 (possibly other versions) throws an exception if no argument is provided.
