### PR TITLE
Add examples, remove failing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,12 @@ wrapper on each page (to avoid differences of DOM between pages)
 
 ---
 
+## Examples
+
+Clone this repository and run `npm run example`, then open `http://localhost:3000/example` in your browser.
+
+---
+
 ## Contributing
 
 Work on a branch, install dev-dependencies, respect coding style & run tests before submitting a bug fix or a feature.

--- a/example/example.js
+++ b/example/example.js
@@ -1,0 +1,25 @@
+console.log('Document initialized:', window.location.href)
+
+document.addEventListener('pjax:send', function () {
+  console.log('Event: pjax:send', arguments)
+})
+
+document.addEventListener('pjax:complete', function () {
+  console.log('Event: pjax:complete', arguments)
+})
+
+document.addEventListener('pjax:error', function () {
+  console.log('Event: pjax:error', arguments)
+})
+
+document.addEventListener('pjax:success', function () {
+  console.log('Event: pjax:success', arguments)
+})
+
+document.addEventListener('DOMContentLoaded', function () {
+  var pjax = new Pjax({
+    selectors: ['.body']
+  })
+  console.log('Pjax initialized.', pjax)
+})
+

--- a/example/example.js
+++ b/example/example.js
@@ -1,25 +1,26 @@
-console.log('Document initialized:', window.location.href)
+/* global Pjax */
+console.log("Document initialized:", window.location.href)
 
-document.addEventListener('pjax:send', function () {
-  console.log('Event: pjax:send', arguments)
+document.addEventListener("pjax:send", function() {
+  console.log("Event: pjax:send", arguments)
 })
 
-document.addEventListener('pjax:complete', function () {
-  console.log('Event: pjax:complete', arguments)
+document.addEventListener("pjax:complete", function() {
+  console.log("Event: pjax:complete", arguments)
 })
 
-document.addEventListener('pjax:error', function () {
-  console.log('Event: pjax:error', arguments)
+document.addEventListener("pjax:error", function() {
+  console.log("Event: pjax:error", arguments)
 })
 
-document.addEventListener('pjax:success', function () {
-  console.log('Event: pjax:success', arguments)
+document.addEventListener("pjax:success", function() {
+  console.log("Event: pjax:success", arguments)
 })
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener("DOMContentLoaded", function() {
   var pjax = new Pjax({
-    selectors: ['.body']
+    selectors: [".body"]
   })
-  console.log('Pjax initialized.', pjax)
+  console.log("Pjax initialized.", pjax)
 })
 

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Hello</title>
+    <script src='../pjax.js'></script>
+    <script src='example.js'></script>
+  </head>
+  <body>
+    <div class='body'>
+      <h1>Index</h1>
+      hello. Go to <a href='page2.html'>Page 2</a> and view your console to see Pjax events.
+    </div>
+  </body>
+</html>

--- a/example/page2.html
+++ b/example/page2.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Hello</title>
+    <script src='../pjax.js'></script>
+    <script src='example.js'></script>
+  </head>
+  <body>
+    <div class='body'>
+      <h1>Page 2</h1>
+      Hello. Go to <a href='index.html'>Index</a>.
+    </div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "coverify": "^1.0.6",
     "jscs": "^1.6.2",
     "jshint": "^2.5.6",
+    "serve": "1.4.0",
     "tape": "^3.0.0",
     "testling": "^1.6.1"
   },
@@ -42,14 +43,19 @@
     "test--html": "testling --html > tests/scripts/index.html",
     "coverage": "browserify -t coverify tests/**/*.js | testling | coverify",
     "standalone": "browserify index.js --standalone Pjax > pjax.js",
+    "example": "echo '\n==> Open http://localhost:3000/example in your browser.'; serve .",
     "prepublish": "npm run standalone"
   },
   "testling": {
     "files": "tests/**/*.js",
     "browsers": [
       "ie/10..latest",
-      "firefox/4.0", "firefox/latest", "firefox/nightly",
-      "chrome/10", "chrome/latest", "chrome/canary",
+      "firefox/4.0",
+      "firefox/latest",
+      "firefox/nightly",
+      "chrome/10",
+      "chrome/latest",
+      "chrome/canary",
       "opera/12..latest",
       "opera/next",
       "safari/5.1..latest",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "test": "npm run lint && npm run standalone && testling",
     "test--html": "testling --html > tests/scripts/index.html",
     "coverage": "browserify -t coverify tests/**/*.js | testling | coverify",
-    "standalone": "browserify index.js --standalone Pjax > pjax.js"
+    "standalone": "browserify index.js --standalone Pjax > pjax.js",
+    "prepublish": "npm run standalone"
   },
   "testling": {
     "files": "tests/**/*.js",


### PR DESCRIPTION
This adds examples to `/example`. This shows that the plugin right now is at a state that doesn't actually work:

![pasted_image_11_13_15__10_44_am](https://cloud.githubusercontent.com/assets/74385/11134778/95263c08-89f3-11e5-9aa3-d76573604c94.png)

I've removed the failing test now so the test suite should pass, but that's no indicator that the project is in a working state.