### PR TITLE
[FIX] #39 - events on top level

### DIFF
--- a/lib/events/trigger.js
+++ b/lib/events/trigger.js
@@ -16,7 +16,7 @@ module.exports = function(els, events, opts) {
 
     forEachEls(els, function(el) {
       var domFix = false
-      if (!el.parentNode) {
+      if (!el.parentNode && el !== document && el !== window) {
         // THANKS YOU IE (9/10//11 concerned)
         // dispatchEvent doesn't work if element is not in the dom
         domFix = true

--- a/tests/lib/events.js
+++ b/tests/lib/events.js
@@ -90,3 +90,21 @@ tape("test events on/off/trigger for multiple elements, multiple events", functi
 
   t.end()
 })
+
+tape("test events on top level elements", function(t) {
+  var el = document;
+
+  el.className = ""
+  on(el, "click", classCb)
+  trigger(el, "click")
+  t.equal(el.className, "on", "attached callback has been fired properly on document")
+
+  el = window;
+
+  el.className = ""
+  on(el, "click", classCb)
+  trigger(el, "click")
+  t.equal(el.className, "on", "attached callback has been fired properly on window")
+
+  t.end()
+})


### PR DESCRIPTION
Events triggered on top level elements (such as window or document)
lead to a HierarchyRequestError due to a fix in IE browsers
where dispatchEvent does not fire if an element is not in the DOM.

The current test is simply to check for the existence of parentNode
However, this means top level elements get added to itself, causing
the error.

The proposed fix simply tests for top level elements in the test.