### PR TITLE
Patch 5

### DIFF
--- a/lib/proto/attach-link.js
+++ b/lib/proto/attach-link.js
@@ -53,14 +53,26 @@ var linkAction = function(el, event) {
   this.loadUrl(el.href, clone(this.options))
 }
 
+var isDefaultPrevented = function(event) {
+  return event.defaultPrevented || event.returnValue === false;
+}
+
 module.exports = function(el) {
   var that = this
 
   on(el, "click", function(event) {
+    if (isDefaultPrevented(event)) {
+      return
+    }
+
     linkAction.call(that, el, event)
   })
 
   on(el, "keyup", function(event) {
+    if (isDefaultPrevented(event)) {
+      return
+    }
+
     // Don’t break browser special behavior on links (like page in new window)
     if (event.which > 1 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
       el.setAttribute(attrKey, "modifier")

--- a/tests/lib/proto/attach-link.js
+++ b/tests/lib/proto/attach-link.js
@@ -56,3 +56,22 @@ tape("test attach link prototype method", function(t) {
 
   t.end()
 })
+
+tape("test attach link preventDefaulted events", function(t) {
+  var callbacked = false
+  var a = document.createElement("a")
+
+  attachLink.call({
+    options: {},
+    loadUrl: function() {
+      callbacked = true
+    }
+  }, a)
+
+  a.href = "#"
+  on(a, "click", preventDefault)
+  trigger(a, "click")
+  t.equal(callbacked, false, "events that are preventDefaulted should not fire callback")
+
+  t.end()
+})


### PR DESCRIPTION
Based off jQuery's isDefaultPrevented(). 

Ensures that event.returnValue is checked for < IE9 support. 