### PR TITLE
fixed an error when using pjax with google analytics

### DIFF
--- a/lib/proto/parse-options.js
+++ b/lib/proto/parse-options.js
@@ -7,7 +7,7 @@ module.exports = function(options){
   this.options.switches = this.options.switches || {}
   this.options.switchesOptions = this.options.switchesOptions || {}
   this.options.history = this.options.history || true
-  this.options.analytics = this.options.analytics || function(options) {
+  this.options.analytics = this.options.analytics || function() {
     // options.backward or options.foward can be true or undefined
     // by default, we do track back/foward hit
     // https://productforums.google.com/forum/#!topic/analytics/WVwMDjLhXYk
@@ -15,7 +15,7 @@ module.exports = function(options){
       _gaq.push(["_trackPageview"])
     }
     if (window.ga) {
-      ga("send", "pageview", {page: options.url, title: options.title})
+      ga("send", "pageview", {page: location.pathname, title: document.title})
     }
   }
   this.options.scrollTo = (typeof this.options.scrollTo === 'undefined') ? 0 : this.options.scrollTo;


### PR DESCRIPTION
`options.analytics()` didn't have any param. so `ga("send", "pageview", {"page": options.url, "title": options.title})` got an error `Cannot read property 'url' of undefined`.

I fixed it by replaced with `ga("send", "pageview", {"page": location.pathname, "title": document.title})`.