### PR TITLE
Polyfill XHR.responseURL so tests pass in old Safari

### DIFF
--- a/tests/lib/request.js
+++ b/tests/lib/request.js
@@ -2,6 +2,18 @@ var tape = require("tape")
 
 var request = require("../../lib/request.js")
 
+// Polyfill responseURL property into XMLHttpRequest if it doesn't exist,
+// just for the purposes of this test
+// This polyfill is not complete; it won't show the updated location if a
+// redirection occurred, but it's fine for our purposes.
+if (!('responseURL' in XMLHttpRequest.prototype)) {
+  var nativeOpen = XMLHttpRequest.prototype.open
+  XMLHttpRequest.prototype.open = function (method, url) {
+    this.responseURL = url
+    return nativeOpen.apply(this, arguments)
+  }
+}
+
 tape("test xhr request", function(t) {
   t.test("- request is made, gets a result, and is cache-busted", function(t) {
     var requestCacheBust = request.bind({


### PR DESCRIPTION
This property is only used in the tests. It doesn't exist in Safari 8 and before, so where it's not available this patch polyfills it, allowing the test to continue.