### PR TITLE
Send the PJAX header with request

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -19,6 +19,7 @@ module.exports = function(location, callback) {
 
   request.open("GET", location, true)
   request.setRequestHeader("X-Requested-With", "XMLHttpRequest")
+  request.setRequestHeader("X-PJAX", "true")
   request.send(null)
   return request
 }


### PR DESCRIPTION
Make it more compatible with the jQuery PJAX and lets the server choose to optimize the response. Sending the list of selectors would be nice, too.