### PR TITLE
Fix bug on IE11 preventing from ajax page refresh

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ Pjax.prototype = {
   },
 
   loadContent: function(html, options) {
-    var tmpEl = document.implementation.createHTMLDocument()
+    var tmpEl = document.implementation.createHTMLDocument("")
 
     // parse HTML attributes to copy them
     // since we are forced to use documentElement.innerHTML (outerHTML can't be used for <html>)


### PR DESCRIPTION
It used to be fixed a long time ago, but was perhaps merged away...