### PR TITLE
Pass the element that triggered Pjax to the pjax:send event

### DIFF
--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -60,7 +60,9 @@ var formAction = function(el, event){
 
   el.setAttribute(attrClick, "submit");
 
-  this.loadUrl(virtLinkElement.href, clone(this.options))
+  const options = clone(this.options);
+  options.triggerElement = el;
+  this.loadUrl(virtLinkElement.href, options);
 
 };
 

--- a/lib/proto/attach-link.js
+++ b/lib/proto/attach-link.js
@@ -53,7 +53,10 @@ var linkAction = function(el, event) {
   }
   this.options.requestOptions = this.options.requestOptions || {};
   el.setAttribute(attrClick, "load")
-  this.loadUrl(el.href, clone(this.options))
+
+  const options = clone(this.options)
+  options.triggerElement = el
+  this.loadUrl(el.href, options)
 }
 
 var isDefaultPrevented = function(event) {


### PR DESCRIPTION
Closes #62.

With this PR, you can access the element that triggered the `pjax:send` event with `event.triggerElement`.