### PR TITLE
Use npmpub like it should since testling is gone

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "coverage": "nyc -x \"tests/**\" npm run coverage-tests",
     "example": "opn http://localhost:3000/example/; serve .",
     "prepublish": "npm run standalone",
-    "#release": "testling does not work in a process launch by npm... :facepalm:",
-    "release": "echo \"npmpub --skip-test --dry && npm test && npmpub --skip-test --skip-cleanup\""
+    "release": "npmpub"
   }
 }


### PR DESCRIPTION
How to cut a release?

See https://github.com/MoOx/npmpub#usage

In short:

make a commit where your bump the package.json number and create a CHANGELOG.md section, then run `npm run release` (or `yarn release`).