### PR TITLE
Fix DOMException in switchElementsAlt() (fixes #103)

### DIFF
--- a/lib/switches.js
+++ b/lib/switches.js
@@ -22,7 +22,7 @@ module.exports = {
     if (newEl.hasAttributes()) {
       const attrs = newEl.attributes;
       for (var i = 0; i < attrs.length; i++) {
-        oldEl.attributes.setNamedItem(attrs[i])
+        oldEl.attributes.setNamedItem(attrs[i].cloneNode())
       }
     }
 


### PR DESCRIPTION
Clone attribute nodes before setting on `oldEl` to prevent the following error:

`
DOMException: Failed to execute 'setNamedItem' on 'NamedNodeMap': The node provided is an attribute node that is already an attribute of another Element; attribute nodes must be explicitly cloned.
`