### PR TITLE
Enhance scrolling behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,10 @@ It's called every time a page is switched, even for history buttons.
 
 Value (in px) to scrollTo when a page is switched.
 
+##### `scrollRestoration` (Boolean, default true)
+
+When set to true, attempt to restore the scroll position when navigating backwards or forwards.
+
 ##### `cacheBust` (Boolean, default true)
 
 When set to true,

--- a/index.js
+++ b/index.js
@@ -247,7 +247,7 @@ Pjax.prototype = {
             url: window.location.href,
             title: document.title,
             uid: this.maxUid,
-            scrollPos: 0
+            scrollPos: [0, 0]
           },
           document.title)
       }
@@ -259,7 +259,7 @@ Pjax.prototype = {
           url: state.href,
           title: state.options.title,
           uid: this.maxUid,
-          scrollPos: 0
+          scrollPos: [0, 0]
         },
         state.options.title,
         state.href)

--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ Pjax.prototype = {
         }
       }
     }
-    else {
+    else if (state.options.scrollRestoration && state.options.scrollPos) {
       window.scrollTo(state.options.scrollPos[0], state.options.scrollPos[1])
     }
 

--- a/lib/proto/parse-options.js
+++ b/lib/proto/parse-options.js
@@ -24,6 +24,7 @@ module.exports = function(options) {
   this.options.cacheBust = (typeof this.options.cacheBust === "undefined") ? true : this.options.cacheBust
   this.options.debug = this.options.debug || false
   this.options.timeout = this.options.timeout || 0
+  this.options.scrollRestoration = (typeof this.options.scrollRestoration !== "undefined") ? this.options.scrollRestoration : true
 
   // we can’t replace body.outerHTML or head.outerHTML
   // it create a bug where new body or new head are created in the dom

--- a/tests/lib/proto/parse-options.js
+++ b/tests/lib/proto/parse-options.js
@@ -53,6 +53,7 @@ tape("test parse initalization options function", function(t) {
     t.deepEqual(body1.options.scrollTo, 0);
     t.deepEqual(body1.options.cacheBust, true);
     t.deepEqual(body1.options.debug, false);
+    t.deepEqual(body1.options.scrollRestoration, true)
     t.end();
   });
 


### PR DESCRIPTION
- Save scroll position with history

  Save scroll position when navigating away from a page, and restore it when navigating back to that page.

  Fixes #30.

- Scroll to element position when URL contains a hash

  When the URL contains a hash, try to find the corresponding element, and if found, scroll to its position.

  Based on darylteo/pjax@4893a2a6574b3490396f83a1863499e8a9ba171e

  Fixes #22.