### PR TITLE
Reset requestOptions after form submission is complete

### DIFF
--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -6,14 +6,18 @@ var clone = require("../clone")
 var attrClick = "data-pjax-click-state"
 
 var formAction = function(el, event) {
-  this.options.requestOptions = {
+  // Since we'll be modifying request options, clone the existing options
+  // so these changes don't persist
+  var options = clone(this.options);
+
+  options.requestOptions = {
     requestUrl: el.getAttribute("action") || window.location.href,
     requestMethod: el.getAttribute("method") || "GET",
   }
 
   // create a testable virtual link of the form action
   var virtLinkElement = document.createElement("a");
-  virtLinkElement.setAttribute("href", this.options.requestOptions.requestUrl);
+  virtLinkElement.setAttribute("href", options.requestOptions.requestUrl);
 
   // Ignore external links.
   if (virtLinkElement.protocol !== window.location.protocol || virtLinkElement.host !== window.location.host) {
@@ -34,7 +38,7 @@ var formAction = function(el, event) {
   }
 
   // if declared as a full reload, just normally submit the form
-  if (this.options.currentUrlFullReload) {
+  if (options.currentUrlFullReload) {
     el.setAttribute(attrClick, "reload");
     return;
   }
@@ -56,12 +60,12 @@ var formAction = function(el, event) {
   // Creating a getString
   var paramsString = (paramObject.map(function(value) {return value.name + "=" + value.value;})).join("&");
 
-  this.options.requestOptions.requestPayload = paramObject;
-  this.options.requestOptions.requestPayloadString = paramsString;
+  options.requestOptions.requestPayload = paramObject;
+  options.requestOptions.requestPayloadString = paramsString;
 
   el.setAttribute(attrClick, "submit");
 
-  var options = clone(this.options);
+
   options.triggerElement = el;
   this.loadUrl(virtLinkElement.href, options);
 };

--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -6,10 +6,11 @@ var clone = require("../clone")
 var attrClick = "data-pjax-click-state"
 
 var formAction = function(el, event) {
-  // Since we'll be modifying request options, clone the existing options
-  // so these changes don't persist
+  // Since loadUrl modifies options and we may add our own modifications below,
+  // clone it so the changes don't persist
   var options = clone(this.options);
 
+  // Initialize requestOptions
   options.requestOptions = {
     requestUrl: el.getAttribute("action") || window.location.href,
     requestMethod: el.getAttribute("method") || "GET",

--- a/lib/proto/attach-link.js
+++ b/lib/proto/attach-link.js
@@ -7,6 +7,13 @@ var attrClick = "data-pjax-click-state"
 var attrKey = "data-pjax-keyup-state"
 
 var linkAction = function(el, event) {
+  // Since loadUrl modifies options and we may add our own modifications below,
+  // clone it so the changes don't persist
+  var options = clone(this.options);
+
+  // Initialize requestOptions since loadUrl expects it to be an object
+  options.requestOptions = {};
+
   // Don’t break browser special behavior on links (like page in new window)
   if (event.which > 1 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
     el.setAttribute(attrClick, "modifier")
@@ -51,10 +58,9 @@ var linkAction = function(el, event) {
     this.reload()
     return
   }
-  this.options.requestOptions = this.options.requestOptions || {};
+
   el.setAttribute(attrClick, "load")
 
-  var options = clone(this.options)
   options.triggerElement = el
   this.loadUrl(el.href, options)
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "jscs . && jshint . --exclude-path .gitignore",
     "standalone": "browserify index.js --standalone Pjax > pjax.js",
     "build-debug": "browserify index.js --debug --standalone Pjax > pjax.js",
-    "tests": "tape -r ./tests/setup.js ./tests/**/*.js",
+    "tests": "tape -r ./tests/setup.js ./tests/lib/*.js ./tests/lib/proto/*.js",
     "test": "npm run lint && npm run tests | tap-spec",
     "coverage-tests": "npm run tests | tap-nyc",
     "coverage": "nyc -x \"tests/**\" npm run coverage-tests",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "jscs . && jshint . --exclude-path .gitignore",
     "standalone": "browserify index.js --standalone Pjax > pjax.js",
     "build-debug": "browserify index.js --debug --standalone Pjax > pjax.js",
-    "tests": "tape -r ./tests/setup.js ./tests/lib/*.js ./tests/lib/proto/*.js",
+    "tests": "tape -r ./tests/setup.js './tests/**/*.js'",
     "test": "npm run lint && npm run tests | tap-spec",
     "coverage-tests": "npm run tests | tap-nyc",
     "coverage": "nyc -x \"tests/**\" npm run coverage-tests",

--- a/tests/lib/proto/attach-form.js
+++ b/tests/lib/proto/attach-form.js
@@ -76,3 +76,21 @@ tape("test attach form preventDefaulted events", function(t) {
 
   t.end()
 })
+
+tape("test options are not modified by attachForm", function(t) {
+  var form = document.createElement("form")
+  var options = {foo: "bar"}
+  var loadUrl = () => {}
+
+  attachForm.call({options, loadUrl}, form)
+
+  var internalUri = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.search
+  form.action = internalUri
+  form.method = "GET"
+  trigger(form, "submit")
+
+  t.equal(1, Object.keys(options).length, "options object that is passed in should not be modified")
+  t.equal("bar", options.foo, "options object that is passed in should not be modified")
+
+  t.end();
+})

--- a/tests/lib/proto/attach-link.js
+++ b/tests/lib/proto/attach-link.js
@@ -75,3 +75,21 @@ tape("test attach link preventDefaulted events", function(t) {
 
   t.end()
 })
+
+tape("test options are not modified by attachLink", function(t) {
+  var a = document.createElement("a")
+  var options = {foo: "bar"}
+  var loadUrl = () => {};
+
+  attachLink.call({options, loadUrl}, a)
+
+  var internalUri = window.location.protocol + "//" + window.location.host + window.location.pathname + window.location.search
+  a.href = internalUri
+
+  trigger(a, "click")
+
+  t.equal(1, Object.keys(options).length, "options object that is passed in should not be modified")
+  t.equal("bar", options.foo, "options object that is passed in should not be modified")
+
+  t.end();
+})


### PR DESCRIPTION
When submitting a form, subsequent requests keep the `requestMethod` and `requestPayload`s; this causes the form to "autosubmit" with the previous values when you load it again.

This PR resets the request options so that subsequent non-form requests go back to using the defaults.