### PR TITLE
Use the same options object in handle-response as in send-request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,8 +67,9 @@ declare class Pjax {
    * @param {string} requestText The raw text of the response. Same as <code>request.responseText</code>.
    * @param {XMLHttpRequest} request The XHR object.
    * @param {string} href The original URI used to initiate the request.
+   * @param options The Pjax options object used for the request
    */
-  handleResponse(requestText: string, request: XMLHttpRequest, href: string): void;
+  handleResponse(requestText: string, request: XMLHttpRequest, href: string, options?: Pjax.IOptions): void;
 
   /**
    * Initiates the request by calling <code>doRequest()</code>.

--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -41,7 +41,7 @@ var formAction = function(el, event) {
     // jscs:disable disallowImplicitTypeConversion
     if (!!element.name && element.attributes !== undefined && tagName !== "button") {
       var type = element.attributes.type
-      // jscs:enable disallowImplicitTypeConversion
+
       if ((!type || type.value !== "checkbox" && type.value !== "radio") || element.checked) {
         // Build array of values to submit
         var values = []

--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -40,6 +40,7 @@ var formAction = function(el, event) {
     var tagName = element.tagName.toLowerCase()
     // jscs:disable disallowImplicitTypeConversion
     if (!!element.name && element.attributes !== undefined && tagName !== "button") {
+      // jscs:enable disallowImplicitTypeConversion
       var type = element.attributes.type
 
       if ((!type || type.value !== "checkbox" && type.value !== "radio") || element.checked) {

--- a/lib/proto/handle-response.js
+++ b/lib/proto/handle-response.js
@@ -3,7 +3,7 @@ var newUid = require("../uniqueid.js")
 var trigger = require("../events/trigger.js")
 
 module.exports = function(responseText, request, href, options) {
-  options = options || clone(this.options);
+  options = clone(options  || this.options)
   options.request = request
 
   // Fail if unable to load HTML via AJAX

--- a/lib/proto/handle-response.js
+++ b/lib/proto/handle-response.js
@@ -2,13 +2,13 @@ var clone = require("../util/clone.js")
 var newUid = require("../uniqueid.js")
 var trigger = require("../events/trigger.js")
 
-module.exports = function(responseText, request, href) {
-  var tempOptions = clone(this.options);
-  tempOptions.request = request
+module.exports = function(responseText, request, href, options) {
+  options = options || clone(this.options);
+  options.request = request
 
   // Fail if unable to load HTML via AJAX
   if (responseText === false) {
-    trigger(document, "pjax:complete pjax:error", tempOptions)
+    trigger(document, "pjax:complete pjax:error", options)
 
     return
   }
@@ -49,13 +49,13 @@ module.exports = function(responseText, request, href) {
   }
 
   this.state.href = href
-  this.state.options = clone(this.options)
+  this.state.options = options
 
   try {
     this.loadContent(responseText, this.options)
   }
   catch (e) {
-    trigger(document, "pjax:error", tempOptions)
+    trigger(document, "pjax:error", options)
 
     if (!this.options.debug) {
       if (console && console.error) {

--- a/lib/send-request.js
+++ b/lib/send-request.js
@@ -13,21 +13,21 @@ module.exports = function(location, options, callback) {
   request.onreadystatechange = function() {
     if (request.readyState === 4) {
       if (request.status === 200) {
-        callback(request.responseText, request, location)
+        callback(request.responseText, request, location, options)
       }
       else if (request.status !== 0) {
-        callback(null, request, location)
+        callback(null, request, location, options)
       }
     }
   }
 
   request.onerror = function(e) {
     console.log(e)
-    callback(null, request, location)
+    callback(null, request, location, options)
   }
 
   request.ontimeout = function() {
-    callback(null, request, location)
+    callback(null, request, location, options)
   }
 
   // Prepare the request payload for forms, if available

--- a/tests/lib/proto/handle-response.js
+++ b/tests/lib/proto/handle-response.js
@@ -37,7 +37,9 @@ tape("test events triggered when handleResponse(false) is called", function(t) {
 
 tape("test when handleResponse() is called normally", function(t) {
   var pjax = {
-    options: {},
+    options: {
+      test: 1
+    },
     loadContent: noop,
     state: {}
   }
@@ -55,7 +57,9 @@ tape("test when handleResponse() is called normally", function(t) {
     scrollPos: [0, 0]
   }, "window.history.state is set correctly")
   t.equals(pjax.state.href, "href", "this.state.href is set correctly")
-  t.same(pjax.state.options, pjax.options, "this.state.options is set correctly")
+  t.equals(Object.keys(pjax.state.options).length, 2, "this.state.options is set correctly")
+  t.same(pjax.state.options.request, request, "this.state.options is set correctly")
+  t.equals(pjax.state.options.test, 1, "this.state.options is set correctly")
 
   t.end()
 })


### PR DESCRIPTION
Instead of cloning `this.options` again in `handle-response.js`, pass the options object from `send-request.js`. This way, `pjax.state.options` will also have the request options.