### PR TITLE
Fix parsing values of option elements in forms

### DIFF
--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -68,7 +68,7 @@ function parseFormElements(el) {
           for (var i = 0; i < element.options.length; i++) {
             opt = element.options[i]
             if (opt.selected) {
-              values.push(opt.value || opt.text)
+              values.push(opt.hasAttribute("value") ? opt.value : opt.text)
             }
           }
         }

--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -67,7 +67,7 @@ function parseFormElements(el) {
 
           for (var i = 0; i < element.options.length; i++) {
             opt = element.options[i]
-            if (opt.selected) {
+            if (opt.selected && !opt.disabled) {
               values.push(opt.hasAttribute("value") ? opt.value : opt.text)
             }
           }


### PR DESCRIPTION
* Fix a bug where the value of `<option>` would not get sent if falsy

  According to the spec, the value attribute should be sent if it exists, even if it's falsy.

* Don't send an `<option>` tag if it's disabled, even if it's selected.

Fixes #158.