### PR TITLE
Fix Edge form support

### DIFF
--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -45,13 +45,10 @@ var formAction = function(el, event) {
 
 function parseFormElements(el) {
   var requestParams = []
+  var formElements = el.elements
 
-  for (var elementKey in el.elements) {
-    if (Number.isNaN(Number(elementKey))) {
-      continue;
-    }
-
-    var element = el.elements[elementKey]
+  for (var i = 0; i < formElements.length; i++) {
+    var element = formElements[i]
     var tagName = element.tagName.toLowerCase()
     // jscs:disable disallowImplicitTypeConversion
     if (!!element.name && element.attributes !== undefined && tagName !== "button") {
@@ -65,8 +62,8 @@ function parseFormElements(el) {
         if (tagName === "select") {
           var opt
 
-          for (var i = 0; i < element.options.length; i++) {
-            opt = element.options[i]
+          for (var j = 0; j < element.options.length; j++) {
+            opt = element.options[j]
             if (opt.selected && !opt.disabled) {
               values.push(opt.hasAttribute("value") ? opt.value : opt.text)
             }
@@ -76,10 +73,10 @@ function parseFormElements(el) {
           values.push(element.value)
         }
 
-        for (var j = 0; j < values.length; j++) {
+        for (var k = 0; k < values.length; k++) {
           requestParams.push({
             name: encodeURIComponent(element.name),
-            value: encodeURIComponent(values[j])
+            value: encodeURIComponent(values[k])
           })
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pjax",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Using a `for... in` loop to iterate a `HTMLElementCollection` as we did in `proto/attach-form.js` is evidently not a very good idea as our implementation doesn't work in Microsoft Edge, so I have swapped it out for a `for` loop that does work across all the browsers that we support.

Fixes #177 