### PR TITLE
Remove keyup event listener for forms

### DIFF
--- a/lib/proto/attach-form.js
+++ b/lib/proto/attach-form.js
@@ -120,10 +120,4 @@ module.exports = function(el) {
   on(el, "submit", function(event) {
     formAction.call(that, el, event)
   })
-
-  on(el, "keyup", function(event) {
-    if (event.keyCode === 13) {
-      formAction.call(that, el, event)
-    }
-  }.bind(this))
 }

--- a/tests/lib/proto/attach-form.js
+++ b/tests/lib/proto/attach-form.js
@@ -99,30 +99,6 @@ tape("test options are not modified by attachForm", function(t) {
   t.end()
 })
 
-tape("test submit triggered by keyboard", function(t) {
-  var form = document.createElement("form")
-  var pjax = {
-    options: {},
-    loadUrl: function() {
-      t.equal(form.getAttribute(attr), "submit", "triggering a internal link actually submits the form")
-    }
-  }
-
-  t.plan(2)
-
-  attachForm.call(pjax, form)
-
-  form.action = window.location.protocol + "//" + window.location.host + "/internal"
-
-  trigger(form, "keyup", {keyCode: 14})
-  t.equal(form.getAttribute(attr), "", "keycode other than 13 doesn't trigger anything")
-
-  trigger(form, "keyup", {keyCode: 13})
-  // see loadUrl defined above
-
-  t.end()
-})
-
 tape("test form elements parsed correctly", function(t) {
   t.plan(1)
 


### PR DESCRIPTION
Let the browser take care of when to do implicit submission.

Fixes #181.